### PR TITLE
Affirm payment plug

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Create a report to help us improve Workarea
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+⚠️**Before you create**⚠️
+Please verify the issue you're experiencing is not part of your Workarea project customizations. The best way to do this is with a [vanilla Workarea installation](https://developer.workarea.com/articles/create-a-new-host-application.html). This will help us spend time on fixes/improvements for the whole community. Thank you!
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Workarea Setup (please complete the following information):**
+ - Workarea Version: [e.g. v3.4.6]
+ - Plugins [e.g. workarea-blog, workarea-sitemaps]
+
+**Attachments**
+If applicable, add any attachments to help explain your problem, things like:
+- screenshots
+- Gemfile.lock
+- test cases
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/documentation-request.md
+++ b/.github/ISSUE_TEMPLATE/documentation-request.md
@@ -1,0 +1,17 @@
+---
+name: Documentation request
+about: Suggest documentation
+title: ''
+labels: documentation
+assignees: ''
+
+---
+
+**Is your documentation related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm confused by [...]
+
+**Describe the article you'd like**
+A clear and concise description of what would be in the documentation article.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for Workarea
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+on: [push]
+
+jobs:
+  static_analysis:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: workarea-commerce/ci/bundler-audit@v1
+    - uses: workarea-commerce/ci/rubocop@v1
+
+  admin_tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+    - uses: workarea-commerce/ci/test@v1
+      with:
+        command: bin/rails app:workarea:test:admin
+
+  core_tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+    - uses: workarea-commerce/ci/test@v1
+      with:
+        command: bin/rails app:workarea:test:core
+
+  storefront_tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+    - uses: workarea-commerce/ci/test@v1
+      with:
+        command: bin/rails app:workarea:test:storefront
+
+  plugins_tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+    - uses: workarea-commerce/ci/test@v1
+      with:
+        command: bin/rails app:workarea:test:plugins

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ node_modules
 yarn.lock
 yarn-error.log
 package-lock.json
+.rubocop-https-*
+.ruby-version

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,3 @@
+inherit_from:
+  - https://raw.githubusercontent.com/workarea-commerce/workarea/master/.rubocop.yml
+

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,5 @@ gemspec
 # your gem to rubygems.org.
 
 # To use a debugger
-# gem 'byebug', group: [:development, :test]
-
-gem 'workarea', github: 'workarea-commerce/workarea'
+# gem 'byebug', group: %i[development test]
+gem 'workarea', github: 'workarea-commerce/workarea', branch: 'v3.5-stable'

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+#!/usr/bin/env rake
 begin
   require 'bundler/setup'
 rescue LoadError
@@ -5,26 +6,30 @@ rescue LoadError
 end
 
 require 'rdoc/task'
+
 RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_dir = 'rdoc'
-  rdoc.title    = 'Affirm'
+  rdoc.title    = 'Workarea3 Plugin'
   rdoc.options << '--line-numbers'
   rdoc.rdoc_files.include('README.md')
   rdoc.rdoc_files.include('lib/**/*.rb')
 end
 
-APP_RAKEFILE = File.expand_path("../test/dummy/Rakefile", __FILE__)
+APP_RAKEFILE = File.expand_path('../test/dummy/Rakefile', __FILE__)
 load 'rails/tasks/engine.rake'
 load 'rails/tasks/statistics.rake'
 load 'workarea/changelog.rake'
 
 require 'rake/testtask'
+
 Rake::TestTask.new(:test) do |t|
   t.libs << 'lib'
   t.libs << 'test'
   t.pattern = 'test/**/*_test.rb'
   t.verbose = false
 end
+
+
 task default: :test
 
 $LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
@@ -32,6 +37,8 @@ require 'workarea/affirm/version'
 
 desc "Release version #{Workarea::Affirm::VERSION} of the gem"
 task :release do
+  host = "https://#{ENV['BUNDLE_GEMS__WEBLINC__COM']}@gems.weblinc.com"
+
   Rake::Task['workarea:changelog'].execute
   system 'git add CHANGELOG.md'
   system 'git commit -m "Update CHANGELOG"'
@@ -39,18 +46,8 @@ task :release do
   system "git tag -a v#{Workarea::Affirm::VERSION} -m 'Tagging #{Workarea::Affirm::VERSION}'"
   system 'git push origin HEAD --follow-tags'
 
-  system "gem build workarea-affirm.gemspec"
+  system 'gem build workarea-affirm.gemspec'
   system "gem push workarea-affirm-#{Workarea::Affirm::VERSION}.gem"
+  system "gem push workarea-affirm-#{Workarea::Affirm::VERSION}.gem --host #{host}"
   system "rm workarea-affirm-#{Workarea::Affirm::VERSION}.gem"
-end
-
-desc 'Run the JavaScript tests'
-ENV['TEASPOON_RAILS_ENV'] = File.expand_path('../test/dummy/config/environment', __FILE__)
-task teaspoon: 'app:teaspoon'
-
-desc 'Start a server at http://localhost:3000/teaspoon for JavaScript tests'
-task :teaspoon_server do
-  Dir.chdir("test/dummy")
-  teaspoon_env = File.expand_path('../test/teaspoon_env.rb', __FILE__)
-  system "RAILS_ENV=test TEASPOON_ENV=#{teaspoon_env} rails s"
 end

--- a/app/assets/javascripts/workarea/storefront/affirm/modules/affirm_payment_triggers.js
+++ b/app/assets/javascripts/workarea/storefront/affirm/modules/affirm_payment_triggers.js
@@ -1,0 +1,29 @@
+WORKAREA.registerModule('affirmPaymentTriggers', (function () {
+    'use strict';
+
+    var setup = function (index, trigger) {
+            var $trigger = $(trigger),
+                $form = $trigger.closest('form'),
+                $payments = $('[name="' + trigger.name + '"]', $form);
+
+            if (typeof affirm === 'undefined') { return; }
+
+            $form.on('submit.affirm', _.partialRight(handleSubmit, $payments));
+        },
+
+        handleSubmit = function (event, $payments) {
+            if ($payments.filter(':checked').val() === 'affirm') {
+                event.preventDefault();
+                affirm.checkout.post();
+            }
+        },
+
+        init = function ($scope) {
+            $('[data-affirm-payment-trigger]', $scope)
+            .each(setup);
+        };
+
+    return {
+        init: init
+    };
+}()));

--- a/app/assets/stylesheets/workarea/storefront/affirm/components/_affirm_as_low_as.scss
+++ b/app/assets/stylesheets/workarea/storefront/affirm/components/_affirm_as_low_as.scss
@@ -1,0 +1,12 @@
+.affirm-as-low-as {}
+.affirm-as-low-as--pdp {}
+.affirm-as-low-as--cart {}
+.affirm-as-low-as--payment {}
+
+    .affirm-as-low-as__subtext {
+        font-weight: bold;
+
+        .payment-icon--affirm {
+            vertical-align: text-bottom;
+        }
+    }

--- a/app/assets/stylesheets/workarea/storefront/affirm/components/_payment_icon.scss
+++ b/app/assets/stylesheets/workarea/storefront/affirm/components/_payment_icon.scss
@@ -1,0 +1,18 @@
+/*------------------------------------*\
+    #PAYMENT-ICON
+\*------------------------------------*/
+
+/**
+* These rules extend `.payment-icon {}` in _payment-icon.scss.
+*/
+
+.payment-icon {}
+
+.payment-icon--affirm {
+    height: 20px;
+    width: 65px;
+    background: url(https://cdn-assets.affirm.com/images/blue_logo-transparent_bg.png);
+    background-position: 0;
+    background-repeat: no-repeat;
+    background-size: contain;
+}

--- a/app/controllers/workarea/affirm_controller.rb
+++ b/app/controllers/workarea/affirm_controller.rb
@@ -1,0 +1,54 @@
+module Workarea
+  class Storefront::AffirmController < Storefront::ApplicationController
+    include Storefront::CurrentCheckout
+
+    before_action :validate_checkout
+
+    def complete
+      check_inventory || return
+      current_order.user_id = current_user.try(:id)
+
+      Workarea::Affirm::Update.new(
+        current_checkout,
+        params[:checkout_token]
+      ).apply
+
+      Pricing.perform(current_order, current_shipping)
+      current_checkout.payment.adjust_tender_amounts(current_order.total_price)
+
+      if current_checkout.place_order && current_checkout.payment.affirm.details['total'] == current_checkout.payment.affirm.amount.cents
+        completed_place_order
+      else
+        incomplete_place_order
+      end
+    end
+
+    private
+
+    def completed_place_order
+      Storefront::OrderMailer.confirmation(current_order.id).deliver_later
+      self.completed_order = current_order
+      clear_current_order
+
+      flash[:success] = t('workarea.storefront.flash_messages.order_placed')
+      redirect_to finished_checkout_destination
+    end
+
+    def incomplete_place_order
+      flash[:error] = t('workarea.storefront.flash_messages.order_place_error')
+
+      payment = current_checkout.payment
+      payment.clear_affirm
+
+      redirect_to checkout_payment_path
+    end
+
+    def finished_checkout_destination
+      if current_admin.present? && current_admin.orders_access?
+        admin.order_path(completed_order)
+      else
+        checkout_confirmation_path
+      end
+    end
+  end
+end

--- a/app/models/workarea/payment.decorator
+++ b/app/models/workarea/payment.decorator
@@ -1,0 +1,31 @@
+module Workarea
+  decorate Payment, with: :affirm do
+    decorated do
+      embeds_one :affirm, class_name: 'Workarea::Payment::Tender::Affirm'
+    end
+
+    def affirm?
+      affirm.present?
+    end
+
+    def set_affirm(attrs)
+      build_affirm unless affirm
+      affirm.attributes = attrs.slice(
+        :checkout_token,
+        :details
+      )
+
+      save!
+    end
+
+    def clear_affirm
+      self.affirm = nil
+      save
+    end
+
+    def set_credit_card(*)
+      self.affirm = nil
+      super
+    end
+  end
+end

--- a/app/models/workarea/payment/authorize/affirm.rb
+++ b/app/models/workarea/payment/authorize/affirm.rb
@@ -1,0 +1,49 @@
+module Workarea
+  class Payment
+    module Authorize
+      class Affirm
+        include OperationImplementation
+        include CreditCardOperation
+
+        def complete!
+          response = gateway.authorize(tender.checkout_token, tender.payment.id)
+          if response.success?
+            transaction.response = ActiveMerchant::Billing::Response.new(
+              true,
+              I18n.t(
+                'workarea.affirm.authorize',
+                amount: transaction.amount
+              ),
+              response.body
+            )
+          else
+            transaction.response = ActiveMerchant::Billing::Response.new(
+              false,
+              I18n.t('workarea.affirm.authorize_failure'),
+              response.body
+            )
+          end
+        end
+
+        def cancel!
+          return unless transaction.success?
+
+          payment_id = transaction.response.params['id']
+          response = gateway.void(payment_id)
+
+          transaction.cancellation = ActiveMerchant::Billing::Response.new(
+            true,
+            I18n.t('workarea.affirm.void'),
+            response.body
+          )
+        end
+
+        private
+
+        def gateway
+          Workarea::Affirm.gateway
+        end
+      end
+    end
+  end
+end

--- a/app/models/workarea/payment/capture/affirm.rb
+++ b/app/models/workarea/payment/capture/affirm.rb
@@ -1,0 +1,45 @@
+module Workarea
+  class Payment
+    class Capture
+      class Affirm
+        include OperationImplementation
+        include CreditCardOperation
+
+        def complete!
+          response = gateway.capture(charge_id, transaction.amount, tender.payment.id)
+
+          transaction.response = if response.success?
+            ActiveMerchant::Billing::Response.new(
+              true,
+              I18n.t(
+                'workarea.affirm.capture',
+               amount: transaction.amount
+              ),
+              response.body
+            )
+            else
+              ActiveMerchant::Billing::Response.new(
+                false,
+                I18n.t('workarea.affirm.capture_failure'),
+                response.body
+              )
+            end
+        end
+
+        def cancel!
+          # No op - no cancel functionality available.
+        end
+
+        private
+
+        def charge_id
+          transaction.reference.response.params['id']
+        end
+
+        def gateway
+          Workarea::Affirm.gateway
+        end
+      end
+    end
+  end
+end

--- a/app/models/workarea/payment/purchase/affirm.rb
+++ b/app/models/workarea/payment/purchase/affirm.rb
@@ -1,0 +1,56 @@
+module Workarea
+  class Payment
+    module Purchase
+      class Affirm
+        include OperationImplementation
+        include CreditCardOperation
+
+        def complete!
+          auth_response = gateway.authorize(tender.checkout_token, tender.payment.id)
+          return auth_error(auth_response.body) unless auth_response.success?
+
+          response = gateway.capture(auth_response.body['id'], transaction.amount, tender.payment.id)
+
+          if response.success?
+            transaction.response = ActiveMerchant::Billing::Response.new(
+              true,
+              I18n.t(
+                'workarea.affirm.purchase',
+                amount: transaction.amount
+              ),
+              auth_response.body
+            )
+          else
+            transaction.response = ActiveMerchant::Billing::Response.new(
+              false,
+              I18n.t('workarea.affirm.purchase_capture_failure'),
+              response.body
+            )
+          end
+        end
+
+        def cancel!
+          # No op - no cancel functionality available.
+        end
+
+        private
+
+        def auth_error(details)
+          transaction.response = ActiveMerchant::Billing::Response.new(
+            false,
+            I18n.t('workarea.affirm.purchase_authorize_failure'),
+            details
+          )
+        end
+
+        def charge_id
+          transaction.reference.response.params['id']
+        end
+
+        def gateway
+          Workarea::Affirm.gateway
+        end
+      end
+    end
+  end
+end

--- a/app/models/workarea/payment/refund/affirm.rb
+++ b/app/models/workarea/payment/refund/affirm.rb
@@ -1,0 +1,46 @@
+module Workarea
+  class Payment
+    class Refund
+      class Affirm
+        include OperationImplementation
+        include CreditCardOperation
+
+        def complete!
+          response = gateway.refund(charge_id, transaction.amount)
+
+          transaction.response = if response.success?
+           ActiveMerchant::Billing::Response.new(
+             true,
+             I18n.t(
+               'workarea.affirm.refund',
+               amount: transaction.amount
+             ),
+             response.body
+           )
+          else
+           ActiveMerchant::Billing::Response.new(
+             false,
+             I18n.t('workarea.affirm.refund_failure'),
+             response.body
+           )
+          end
+        end
+
+        def cancel!
+          # No op - no cancel functionality available.
+        end
+
+        private
+
+        def charge_id
+          tran = tender.transactions.detect { |t| t.success? & %w[authorize purchase].include?(t.action) }
+          tran.response.params['id']
+        end
+
+        def gateway
+          Workarea::Affirm.gateway
+        end
+      end
+    end
+  end
+end

--- a/app/models/workarea/payment/tender/affirm.rb
+++ b/app/models/workarea/payment/tender/affirm.rb
@@ -1,0 +1,18 @@
+module Workarea
+  class Payment
+    class Tender
+      class Affirm < Tender
+        field :checkout_token, type: String
+        field :details, type: Hash
+
+        def slug
+          :affirm
+        end
+
+        def set_amount(amount)
+          self.amount = amount
+        end
+      end
+    end
+  end
+end

--- a/app/services/workarea/affirm/order.rb
+++ b/app/services/workarea/affirm/order.rb
@@ -1,0 +1,106 @@
+module Workarea
+  module Affirm
+    class Order
+      module ProductUrl
+        include Workarea::I18n::DefaultUrlOptions
+        include Storefront::Engine.routes.url_helpers
+        extend self
+      end
+
+      module ProductImageUrl
+        include Workarea::ApplicationHelper
+        include Workarea::I18n::DefaultUrlOptions
+        include ActionView::Helpers::AssetUrlHelper
+        include Core::Engine.routes.url_helpers
+        extend self
+
+        def mounted_core
+          self
+        end
+      end
+
+      attr_reader :order, :options
+
+      def initialize(order_id, options = {})
+        wa_order = Workarea::Order.find(order_id)
+        @order = Workarea::Storefront::OrderViewModel.wrap(wa_order)
+        @options = options
+      end
+
+      def to_json(*_args)
+        to_hash.to_json
+      end
+
+      def to_hash
+        {
+          merchant: merchant,
+          shipping: shipping,
+          billing: billing,
+          items: items,
+          order_id: order.id,
+          shipping_amount: order.shipping_total.cents,
+          tax_amount: order.tax_total.cents,
+          total: order.order_balance.cents
+        }
+      end
+
+      private
+
+      def merchant
+        {
+          user_confirmation_url: Storefront::Engine.routes.url_helpers.complete_affirm_url(host: host),
+          user_cancel_url: Storefront::Engine.routes.url_helpers.checkout_payment_url(host: host),
+          user_confirmation_url_action: 'GET',
+          name: site_name
+        }
+      end
+
+      def shipping
+        address_data_for(order.shipping_address)
+      end
+
+      def billing
+        address_data_for(order.billing_address)
+      end
+
+      def address_data_for(address)
+        {
+          name: {
+            first: address.first_name,
+            last: address.last_name
+          },
+          address: {
+            line1: address.street,
+            city: address.city,
+            state: address.region,
+            zipcode: address.postal_code,
+            country: address.country.alpha3
+          },
+          phone_number: address.phone_number,
+          email: order.email
+        }
+      end
+
+      def items
+        Storefront::OrderItemViewModel.wrap(order.items).map do |item|
+          {
+            display_name: item.product_name,
+            sku: item.sku,
+            unit_price: item.original_price.cents,
+            qty: item.quantity,
+            item_image_url: ProductImageUrl.product_image_url(item.image, :detail),
+            item_url: ProductUrl.product_url(id: item.product.to_param, host: Workarea.config.host)
+          }
+        end
+      end
+
+      def site_name
+        Workarea.config.affirm_merchant_name.to_s
+      end
+
+      def host
+        "https://#{Workarea.config.host}"
+      end
+    end
+  end
+end

--- a/app/services/workarea/affirm/update.rb
+++ b/app/services/workarea/affirm/update.rb
@@ -1,0 +1,29 @@
+module Workarea
+  module Affirm
+    class Update
+      attr_reader :checkout, :checkout_token
+
+      def initialize(checkout, checkout_token)
+        @checkout = checkout
+        @checkout_token = checkout_token
+      end
+
+      def details
+        @details ||= Affirm.gateway.get_checkout(checkout_token)
+      end
+
+      def apply
+        payment = checkout.payment
+        order = checkout.order
+
+        payment.set_affirm(
+          checkout_token: checkout_token,
+          details: details.body
+        )
+        payment.adjust_tender_amounts(order.total_price)
+
+        order.save && payment.save
+      end
+    end
+  end
+end

--- a/app/view_models/workarea/storefront/checkout/payment_view_model.decorator
+++ b/app/view_models/workarea/storefront/checkout/payment_view_model.decorator
@@ -1,0 +1,11 @@
+module Workarea
+  decorate Storefront::Checkout::PaymentViewModel, with: :affirm do
+    decorated do
+      delegate :affirm?, to: :payment
+    end
+
+    def using_new_card?
+      super && !affirm?
+    end
+  end
+end

--- a/app/views/workarea/admin/orders/tenders/_affirm.html.haml
+++ b/app/views/workarea/admin/orders/tenders/_affirm.html.haml
@@ -1,0 +1,2 @@
+%li= t('workarea.affirm.tender_description')
+

--- a/app/views/workarea/storefront/affirm/_affirm_javascript_sdk.html.haml
+++ b/app/views/workarea/storefront/affirm/_affirm_javascript_sdk.html.haml
@@ -1,0 +1,8 @@
+- if Workarea::Affirm.api_configured?
+  :javascript
+    _affirm_config = {
+       public_api_key:  "#{Workarea.config.affirm_public_key}",
+       script:          "#{Workarea::Affirm.js_sdk_url}"
+     };
+    (function(m,g,n,d,a,e,h,c){var b=m[n]||{},k=document.createElement(e),p=document.getElementsByTagName(e)[0],l=function(a,b,c){return function(){a[b]._.push([c,arguments])}};b[d]=l(b,d,"set");var f=b[d];b[a]={};b[a]._=[];f._=[];b._=[];b[a][h]=l(b,a,h);b[c]=function(){b._.push([h,arguments])};a=0;for(c="set add save post open empty reset on off trigger ready setProduct".split(" ");a<c.length;a++)f[c[a]]=l(b,d,c[a]);a=0;for(c=["get","token","url","items"];a<c.length;a++)f[c[a]]=function(){};k.async=
+    !0;k.src=g[e];p.parentNode.insertBefore(k,p);delete g[e];f(g);m[n]=b})(window,_affirm_config,"affirm","checkout","ui","script","ready","jsReady");

--- a/app/views/workarea/storefront/carts/_affirm_cart_promo_messaging.html.haml
+++ b/app/views/workarea/storefront/carts/_affirm_cart_promo_messaging.html.haml
@@ -1,0 +1,7 @@
+- if Workarea::Affirm.api_configured? && @cart.total_price >= Workarea.config.affirm_minimum_order_value.to_m
+  .affirm-as-low-as.affirm-as-low-as--cart{ data: { amount: @cart.total_price.cents, affirm_type: 'text', learnmore_show: 'false'}}
+  .affirm-as-low-as__subtext
+    = t('workarea.storefront.affirm.select')
+    %span.payment-icon.payment-icon--affirm
+    = t('workarea.storefront.affirm.payment_step')
+

--- a/app/views/workarea/storefront/checkouts/_affirm_cart.html.haml
+++ b/app/views/workarea/storefront/checkouts/_affirm_cart.html.haml
@@ -1,0 +1,3 @@
+- if Workarea::Affirm.api_configured?
+  :javascript
+    affirm.checkout(#{raw(Workarea::Affirm::Order.new(current_order.id, request: request).to_json)});

--- a/app/views/workarea/storefront/checkouts/_affirm_payment.html.haml
+++ b/app/views/workarea/storefront/checkouts/_affirm_payment.html.haml
@@ -1,0 +1,12 @@
+- if Workarea::Affirm.api_configured? && current_order.total_price >= Workarea.config.affirm_minimum_order_value.to_m
+  .checkout-payment__primary-method
+    .button-property
+      .value= radio_button_tag 'payment', 'affirm', step.affirm?, data: { affirm_payment_trigger: '' }
+      = label_tag 'payment[affirm]', nil, class: 'button-property__name' do
+        %span.payment-icon.payment-icon--affirm
+    %p.checkout-payment__primary-method-description
+      %span.affirm-as-low-as.affirm-as-low-as--payment{ data: { amount: step.order.total_price.cents, affirm_type: 'text', learnmore_show: 'false'}}
+    %p.checkout-payment__primary-method-edit
+      %span= t('workarea.storefront.affirm.on_continue')
+
+    = render 'workarea/storefront/checkouts/affirm_cart'

--- a/app/views/workarea/storefront/order_mailer/tenders/_affirm.html.haml
+++ b/app/views/workarea/storefront/order_mailer/tenders/_affirm.html.haml
@@ -1,0 +1,4 @@
+%p{ style: "margin: 0 0 6px; font: 13px/1.5 arial; color: #{@config.text_color};" }
+  = t('workarea.affirm.tender_description')
+
+

--- a/app/views/workarea/storefront/order_mailer/tenders/_affirm.text.erb
+++ b/app/views/workarea/storefront/order_mailer/tenders/_affirm.text.erb
@@ -1,0 +1,1 @@
+<%= t('workarea.affirm.tender_description')%>

--- a/app/views/workarea/storefront/orders/tenders/_affirm.html.haml
+++ b/app/views/workarea/storefront/orders/tenders/_affirm.html.haml
@@ -1,0 +1,5 @@
+.data-card
+  .data-card__cell
+    %p.data-card__line
+      = t('workarea.affirm.tender_description')
+      = number_to_currency(tender.amount)

--- a/app/views/workarea/storefront/products/_affirm_product_promo_messaging.html.haml
+++ b/app/views/workarea/storefront/products/_affirm_product_promo_messaging.html.haml
@@ -1,0 +1,6 @@
+- if Workarea::Affirm.api_configured? &&  @product.sell_min_price.present?
+  .affirm-as-low-as.affirm-as-low-as--cart{ data: { amount: @product.sell_min_price.cents, affirm_type: 'text', learnmore_show: 'false'}}
+  .affirm-as-low-as__subtext
+    Select
+    %span.payment-icon.payment-icon--affirm
+    on Payment Step of checkout

--- a/config/initializers/appends.rb
+++ b/config/initializers/appends.rb
@@ -1,0 +1,29 @@
+Workarea.append_partials(
+  'storefront.document_head',
+  'workarea/storefront/affirm/affirm_javascript_sdk'
+)
+
+Workarea::Plugin.append_partials(
+  'storefront.cart_show',
+  'workarea/storefront/carts/affirm_cart_promo_messaging'
+)
+
+Workarea::Plugin.append_partials(
+  'storefront.product_pricing_details',
+  'workarea/storefront/products/affirm_product_promo_messaging'
+)
+
+Workarea::Plugin.append_partials(
+  'storefront.payment_method',
+  'workarea/storefront/checkouts/affirm_payment'
+)
+
+Workarea::Plugin.append_stylesheets(
+  'storefront.components',
+  ['workarea/storefront/affirm/components/affirm_as_low_as', 'workarea/storefront/affirm/components/payment_icon']
+)
+
+Workarea::Plugin.append_javascripts(
+  'storefront.modules',
+  'workarea/storefront/affirm/modules/affirm_payment_triggers'
+)

--- a/config/initializers/configuration.rb
+++ b/config/initializers/configuration.rb
@@ -1,0 +1,32 @@
+Workarea::Configuration.define_fields do
+  fieldset 'Affirm', namespaced: true do
+    field 'Public Key',
+      type: :string,
+      description: 'Public API key. Found in the Affirm API Keys admin section.',
+      allow_blank: true,
+      encrypted: false
+
+    field 'Private Key',
+      type: :string,
+      description: 'Private API key used for server side calls. Found in the Affirm API Keys admin section.',
+      allow_blank: true,
+      encrypted: true
+
+    field 'Use Production Environment',
+      type: :boolean,
+      description: 'Uses the production API and Javascript SDK URLS.',
+      default: false
+
+    field 'Merchant Name',
+      type: :string,
+      description: 'Name of merchant that display in Affirm checkout.',
+      allow_blank: true,
+      encrypted: false
+
+    field 'Minimum Order Value',
+      type: :float,
+      description: 'Minimum order total required for Affirm. Affirm will not show as a payment option if this threshold is not met. Leave this field blank for no minimum.',
+      allow_blank: true,
+      encrypted: false
+  end
+end

--- a/config/initializers/workarea.rb
+++ b/config/initializers/workarea.rb
@@ -1,3 +1,7 @@
 Workarea.configure do |config|
-  # Add custom configuration here
+  config.tender_types.append(:affirm)
+
+  config.affirm = ActiveSupport::Configurable::Configuration.new
+  config.affirm.api_timeout = 5
+  config.affirm.open_timeout = 5
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,38 @@
+---
+en:
+  workarea:
+    admin:
+      orders:
+        tenders:
+          affirm:
+            title: Affirm
+    storefront:
+      orders:
+        tenders:
+          affirm: Affirm
+      affirm:
+        address_error: We can not ship to this address. Please enter a new address.
+        cancel_message: Your Affirm order has been cancelled. Please select another payment method.
+        check_out: Check Out with affirm
+        checkout_submit_text: Continue to Affirm
+        on_continue: When you continue, you will be taken to the Affirm website to complete your order.
+        paid_with_affirm: Paid with Affirm
+        payment_error: There was a problem processing your Affirm payment.
+        affirm: Affirm
+        learn_more: Learn More
+        select: Select
+        payment_step: on Payment Step of checkout
+    affirm:
+      authorize: "%{amount} has been authorized"
+      capture: "%{amount} has been captured"
+      purchase: "%{amount} has been purchased"
+      refund: "%{amount} has been refunded"
+      void: "Aftperay Transaction has been voided"
+      authorize_failure: "Affirm authorize has failed"
+      capture_failure: "Affirm capture has failed"
+      purchase_failure: "Affirm purchase has failed"
+      refund_failure: "Affirm refund has failed"
+      tender_description: "Paid with Affirm"
+      purchase_authorize_failure: "Affirm authorize has failed during the purchase operation"
+      purchase_capture_failure: "Affirm capture has failed during the purchase operation"
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,2 +1,3 @@
-Rails.application.routes.draw do
+Workarea::Storefront::Engine.routes.draw do
+  get 'affirm/complete' => 'affirm#complete', as: :complete_affirm
 end

--- a/lib/workarea/affirm.rb
+++ b/lib/workarea/affirm.rb
@@ -2,7 +2,46 @@ require 'workarea'
 require 'workarea/affirm/engine'
 require 'workarea/affirm/version'
 
+require 'workarea/affirm/gateway'
+require 'workarea/affirm/response'
+require 'workarea/affirm/bogus_gateway'
+
 module Workarea
   module Affirm
+        def self.public_key
+      Workarea.config.affirm_public_key
+    end
+
+    def self.private_key
+      Workarea.config.affirm_private_key
+    end
+
+    def self.api_configured?
+      public_key.present? && private_key.present?
+    end
+
+    def self.js_sdk_url
+      if test?
+        "https://cdn1-sandbox.affirm.com/js/v2/affirm.js"
+      else
+        "https://cdn1.affirm.com/js/v2/affirm.js"
+      end
+    end
+
+    def self.test?
+      !Workarea.config.affirm_use_production_environment
+    end
+
+    def self.gateway(_options = {})
+      if Rails.env.test?
+        Affirm::BogusGateway.new
+      else
+        Affirm::Gateway.new(
+          test: test?,
+          public_key: public_key,
+          private_key: private_key
+        )
+      end
+    end
   end
 end

--- a/lib/workarea/affirm/bogus_gateway.rb
+++ b/lib/workarea/affirm/bogus_gateway.rb
@@ -1,0 +1,302 @@
+module Workarea
+  module Affirm
+    class BogusGateway
+      def initialize(*); end
+
+      def get_checkout(token)
+        b = if token == 'total_error'
+              get_checkout_response_total_error_body
+            else
+              get_checkout_response_body
+            end
+        Response.new(response(b))
+      end
+
+      def capture(_payment_id, _amount, _request_id)
+        b = {
+          "fee": 600,
+          "created": '2016-03-18T00:03:44Z',
+          "order_id": 'JKLM4321',
+          "currency": 'USD',
+          "amount": 6100,
+          "type": 'capture',
+          "id": 'O5DZHKL942503649',
+          "transaction_id": '6dH0LrrgUaMD7Llc',
+          "merchant_transaction_id": 'A2189192837'
+        }
+
+        Response.new(response(b, 200))
+      end
+
+      def authorize(_token, _order_id = '', _request_id)
+        Response.new(response(payment_response_body, 200))
+      end
+
+      def purchase(_token, _order_id = '', _request_id)
+        Response.new(response(payment_response_body, 200))
+      end
+
+      def refund(_affirm_order_id, _amount, _request_id)
+        b = {
+          "created": '2014-03-18T19:20:30Z',
+          "fee_refunded": 1500,
+          "amount": 50_000,
+          "type": 'refund',
+          "id": 'OWA49MWUCA29SBVQ',
+          "transaction_id": 'r86zdkHONPcaiVJJ'
+        }
+
+        Response.new(response(b))
+      end
+
+      def void(_payment_id)
+        Response.new(response(payment_response_body))
+      end
+
+      private
+
+      def response(body, status = 200)
+        response = Faraday.new do |builder|
+          builder.adapter :test do |stub|
+            stub.get('/v1/bogus') { |_env| [status, {}, body.to_json] }
+          end
+        end
+        response.get('/v1/bogus')
+      end
+
+      def get_checkout_response_body
+        {
+          "api_version": 'v2',
+          "billing": {
+            "address": {
+              "city": 'Philadelphia',
+              "country": 'USA',
+              "line1": '22 south 3rd street',
+              "line2": '',
+              "state": 'PA',
+              "zipcode": '19063'
+            },
+            "email": 'jyucis@weblinc.com',
+            "name": {
+              "first": 'Jeffrey',
+              "full": 'Jeffrey Yucis',
+              "last": 'Yucis'
+            },
+            "phone_number": '+1-553-750-7743'
+          },
+          "checkout_flow_type": 'classic',
+          "checkout_status": 'confirmed',
+          "checkout_type": 'merchant',
+          "config": {
+            "user_confirmation_url_action": 'GET'
+          },
+          "currency": 'USD',
+          "financing_program_external_name": 'standard_3_6_12',
+          "financing_program_name": 'standard_3_6_12',
+          "items": {
+            "OBWH-01": {
+              "display_name": 'Product 1',
+              "item_image_url": '/product_images/placeholder/detail.jpg?c=1580497327',
+              "item_type": 'physical',
+              "item_url": 'http://www.example.com/products/w-h-smith-collection-t-shift',
+              "qty": 1,
+              "sku": 'SKU 1',
+              "unit_price": 10_000
+            }
+          },
+          "loan_type": 'classic',
+          "merchant": {
+            "name": 'Workarea',
+            "public_api_key": 'CXIR9J2CJESHKXGJ',
+            "user_cancel_url": 'http://localhost:3000/checkout/payment',
+            "user_confirmation_url": 'http://localhost:3000/affirm/complete',
+            "user_confirmation_url_action": 'GET'
+          },
+          "merchant_external_reference": 'DA76560945',
+          "meta": {
+            "__affirm_tracking_uuid": 'f0c19176-0eca-469e-bcec-b42bf46e2b41',
+            "release": 'false',
+            "user_timezone": 'America/New_York'
+          },
+          "metadata": {
+            "checkout_channel_type": 'online'
+          },
+          "mfp_rule_input_data": {
+            "items": {
+              "OBWH-01": {
+                "display_name": 'W H Smith Collection T-Shift',
+                "item_image_url": '/product_images/placeholder/detail.jpg?c=1580497327',
+                "item_type": 'physical',
+                "item_url": 'http://www.example.com/products/w-h-smith-collection-t-shift',
+                "qty": 1,
+                "sku": 'OBWH-01',
+                "unit_price": 10_000
+              }
+            },
+            "metadata": {
+              "checkout_channel_type": 'online'
+            },
+            "total": 10_600
+          },
+          "order_id": 'DA76560945',
+          "product": 'checkout',
+          "shipping_amount": 600,
+          "tax_amount": 0,
+          "total": 10_600
+        }
+      end
+
+      def get_checkout_response_total_error_body
+        {
+          "api_version": 'v2',
+          "billing": {
+            "address": {
+              "city": 'Philadelphia',
+              "country": 'USA',
+              "line1": '22 south 3rd street',
+              "line2": '',
+              "state": 'PA',
+              "zipcode": '19063'
+            },
+            "email": 'jyucis@weblinc.com',
+            "name": {
+              "first": 'Jeffrey',
+              "full": 'Jeffrey Yucis',
+              "last": 'Yucis'
+            },
+            "phone_number": '+1-553-750-7743'
+          },
+          "checkout_flow_type": 'classic',
+          "checkout_status": 'confirmed',
+          "checkout_type": 'merchant',
+          "config": {
+            "user_confirmation_url_action": 'GET'
+          },
+          "currency": 'USD',
+          "financing_program_external_name": 'standard_3_6_12',
+          "financing_program_name": 'standard_3_6_12',
+          "items": {
+            "OBWH-01": {
+              "display_name": 'Product 1',
+              "item_image_url": '/product_images/placeholder/detail.jpg?c=1580497327',
+              "item_type": 'physical',
+              "item_url": 'http://www.example.com/products/w-h-smith-collection-t-shift',
+              "qty": 1,
+              "sku": 'SKU 1',
+              "unit_price": 10_000
+            }
+          },
+          "loan_type": 'classic',
+          "merchant": {
+            "name": 'Workarea',
+            "public_api_key": 'CXIR9J2CJESHKXGJ',
+            "user_cancel_url": 'http://localhost:3000/checkout/payment',
+            "user_confirmation_url": 'http://localhost:3000/affirm/complete',
+            "user_confirmation_url_action": 'GET'
+          },
+          "merchant_external_reference": 'DA76560945',
+          "meta": {
+            "__affirm_tracking_uuid": 'f0c19176-0eca-469e-bcec-b42bf46e2b41',
+            "release": 'false',
+            "user_timezone": 'America/New_York'
+          },
+          "metadata": {
+            "checkout_channel_type": 'online'
+          },
+          "mfp_rule_input_data": {
+            "items": {
+              "OBWH-01": {
+                "display_name": 'W H Smith Collection T-Shift',
+                "item_image_url": '/product_images/placeholder/detail.jpg?c=1580497327',
+                "item_type": 'physical',
+                "item_url": 'http://www.example.com/products/w-h-smith-collection-t-shift',
+                "qty": 1,
+                "sku": 'OBWH-01',
+                "unit_price": 10_000
+              }
+            },
+            "metadata": {
+              "checkout_channel_type": 'online'
+            },
+            "total": 10_600
+          },
+          "order_id": 'DA76560945',
+          "product": 'checkout',
+          "shipping_amount": 600,
+          "tax_amount": 0,
+          "total": 1
+        }
+      end
+
+      def capture_error_response_body
+        {
+          "errorCode": 'declined',
+          "errorId": 'c4d64cbc3e61a26f',
+          "message": 'Payment declined',
+          "httpStatusCode": 402
+        }
+      end
+
+      def payment_response_body
+        {
+          "id": 'ALO4-UVGR',
+          "created": '2016-03-18T19:19:04Z',
+          "currency": 'USD',
+          "amount": 6100,
+          "auth_hold": 6100,
+          "payable": 0,
+          "void": false,
+          "expires": '2016-04-18T19:19:04Z',
+          "order_id": 'JKLM4321',
+          "events": [
+            {
+              "created": '2014-03-20T14:00:33Z',
+              "currency": 'USD',
+              "id": 'UI1ZOXSXQ44QUXQL',
+              "transaction_id": 'TpR3Xrx8TkvuGio0',
+              "type": 'auth'
+            }
+          ],
+          "details": {
+            "items": {
+              "sweater-a92123": {
+                "sku": 'sweater-a92123',
+                "display_name": 'Sweater',
+                "qty": 1,
+                "item_type": 'physical',
+                "item_image_url": 'http://placehold.it/350x150',
+                "item_url": 'http://placehold.it/350x150',
+                "unit_price": 5000
+              }
+            },
+            "order_id": 'JKLM4321',
+            "shipping_amount": 400,
+            "tax_amount": 700,
+            "shipping": {
+              "name": {
+                "full": 'John Doe'
+              },
+              "address": {
+                "line1": '325 Pacific Ave',
+                "city": 'San Francisco',
+                "state": 'CA',
+                "zipcode": '94112',
+                "country": 'USA'
+              }
+            },
+            "discounts": {
+              "RETURN5": {
+                "discount_amount": 500,
+                "discount_display_name": 'Returning customer 5% discount'
+              },
+              "PRESDAY10": {
+                "discount_amount": 1000,
+                "discount_display_name": "President's Day 10% off"
+              }
+            }
+          }
+        }
+      end
+    end
+  end
+end

--- a/lib/workarea/affirm/gateway.rb
+++ b/lib/workarea/affirm/gateway.rb
@@ -1,0 +1,105 @@
+module Workarea
+  module Affirm
+    class Gateway
+      attr_reader :public_key, :private_key, :test
+
+      def initialize(options = {})
+        @public_key = options[:public_key]
+        @private_key = options[:private_key]
+        @test = options[:test]
+      end
+
+      def get_checkout(token)
+          response = connection.get do |req|
+          req.url "/api/v2/checkout/#{token}"
+        end
+
+        Affirm::Response.new(response)
+      end
+
+      def authorize(token, order_id)
+        body = {
+          checkout_token: token,
+          order_id: order_id
+        }
+        response = connection.post do |req|
+          req.url "/api/v2/charges"
+          req.body = body.to_json
+        end
+
+        Affirm::Response.new(response)
+      end
+
+      def capture(charge_id, amount, order_id)
+        body = {
+          amount:  amount.cents,
+          order_id: order_id
+        }
+        response = connection.post do |req|
+          req.url "api/v2/charges/#{charge_id}/capture"
+          req.body = body.to_json
+        end
+
+        Affirm::Response.new(response)
+      end
+
+      def refund(charge_id, amount)
+        body = {
+          amount:  amount.cents,
+          type: "refund"
+        }
+
+        response = connection.post do |req|
+          req.url "/api/v2/charges/#{charge_id}/refund"
+          req.body = body.to_json
+        end
+
+        Affirm::Response.new(response)
+      end
+
+      def void(charge_id)
+        response = connection.post do |req|
+          req.url "/api/v2/charges/#{charge_id}/void"
+        end
+
+        Affirm::Response.new(response)
+      end
+
+      private
+
+      def connection
+        headers = {
+          "Content-Type" => "application/json",
+          "Accept"       => "application/json",
+          "Authorization" => "Basic #{encoded_credentials}",
+        }
+
+        request_timeouts = {
+          timeout: Workarea.config.affirm[:api_timeout],
+          open_timeout: Workarea.config.affirm[:open_timeout]
+        }
+
+        conn = Faraday.new(url: rest_endpoint, headers: headers, request: request_timeouts)
+        conn.basic_auth(public_key, private_key)
+        conn
+      end
+
+      def encoded_credentials
+        Base64.encode64("#{public_key}:#{private_key}") \
+          .gsub(/\n/, '').strip
+      end
+
+      def test?
+        test
+      end
+
+      def rest_endpoint
+        if test?
+          "https://sandbox.affirm.com"
+        else
+          "https://api.affirm.com"
+        end
+      end
+    end
+  end
+end

--- a/lib/workarea/affirm/response.rb
+++ b/lib/workarea/affirm/response.rb
@@ -1,0 +1,22 @@
+module Workarea
+  module Affirm
+    class Response
+      def initialize(response)
+        @response = response
+      end
+
+      def success?
+        @response.present? && (@response.status == 201 || @response.status == 200)
+      end
+
+      def body
+        return {} unless @response.body.present? && @response.body != "null"
+        JSON.parse(@response.body)
+      end
+
+      def status
+        @response.status
+      end
+    end
+  end
+end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -30,4 +30,3 @@ module Dummy
     # the framework and any gems in your application.
   end
 end
-

--- a/test/integration/workarea/storefront/affirm_integration_test.rb
+++ b/test/integration/workarea/storefront/affirm_integration_test.rb
@@ -1,0 +1,119 @@
+require 'test_helper'
+
+module Workarea
+  module Storefront
+    class Affirm < Workarea::IntegrationTest
+      setup :set_checkout
+
+      def set_checkout
+        create_tax_category(
+          name: 'Sales Tax',
+          code: '001',
+          rates: [{ percentage: 0.07, country: 'US', region: 'PA' }]
+        )
+
+        product = create_product(
+          variants: [{ sku: 'SKU1', regular: 6.to_m, tax_code: '001' }]
+        )
+
+        create_shipping_service(
+          carrier: 'UPS',
+          name: 'Ground',
+          service_code: '03',
+          tax_code: '001',
+          rates: [{ price: 7.to_m }]
+        )
+
+        post storefront.cart_items_path,
+          params: {
+            product_id: product.id,
+            sku: product.skus.first,
+            quantity: 2
+          }
+
+        patch storefront.checkout_addresses_path,
+          params: {
+            email: 'bcrouse@workarea.com',
+            billing_address: {
+              first_name:   'Ben',
+              last_name:    'Crouse',
+              street:       '12 N. 3rd St.',
+              city:         'Philadelphia',
+              region:       'PA',
+              postal_code:  '19106',
+              country:      'US',
+              phone_number: '2159251800'
+            },
+            shipping_address: {
+              first_name:   'Ben',
+              last_name:    'Crouse',
+              street:       '22 S. 3rd St.',
+              city:         'Philadelphia',
+              region:       'PA',
+              postal_code:  '19106',
+              country:      'US',
+              phone_number: '2159251800'
+            }
+          }
+
+        patch storefront.checkout_shipping_path
+      end
+
+      def test_handling_affirm_payment_error
+        payment = Payment.find(order.id)
+
+        params = { checkout_token: 'total_error' }
+        get storefront.complete_affirm_path(params)
+
+        payment.reload
+        refute(payment.affirm?)
+      end
+
+      def test_placing_order_from_affirm
+        Workarea::Affirm::BogusGateway.any_instance.stubs(:get_checkout).returns(get_checkout_response(order.total_price.cents))
+
+        payment = Payment.find(order.id)
+
+        params = { checkout_token: '1234' }
+
+        get storefront.complete_affirm_path(params)
+
+        payment.reload
+        order.reload
+
+        assert(order.placed?)
+
+        transactions = payment.tenders.first.transactions
+        assert_equal(1, transactions.size)
+        assert(transactions.first.success?)
+        assert_equal('authorize', transactions.first.action)
+      end
+
+      private
+
+      def order
+         @order ||= Order.first
+       end
+
+      def product
+        @product ||= create_product(
+          variants: [{ sku: 'SKU1', regular: 6.to_m, tax_code: '001' }]
+        )
+      end
+
+      def get_checkout_response(amount)
+        b = { "total": amount }
+          Workarea::Affirm::Response.new(response(b))
+      end
+
+      def response(body, status = 200)
+        response = Faraday.new do |builder|
+          builder.adapter :test do |stub|
+            stub.get("/v2/bogus") { |env| [ status, {}, body.to_json ] }
+          end
+        end
+        response.get("/v2/bogus")
+      end
+    end
+  end
+end

--- a/test/models/workarea/payment/affirm_payment_integration_test.rb
+++ b/test/models/workarea/payment/affirm_payment_integration_test.rb
@@ -1,0 +1,81 @@
+require 'test_helper'
+
+module Workarea
+  class AffirmPaymentIntegrationTest < Workarea::TestCase
+    def test_auth_capture
+      transaction = tender.build_transaction(action: 'authorize')
+      Payment::Purchase::Affirm.new(tender, transaction).complete!
+
+      assert(transaction.success?)
+      transaction.save!
+
+      capture = Payment::Capture.new(payment: payment)
+      capture.allocate_amounts!(total: 5.to_m)
+      assert(capture.valid?)
+      capture.complete!
+
+      capture_transaction = payment.transactions.detect(&:captures)
+      assert(capture_transaction.valid?)
+    end
+
+    def test_auth
+      transaction = tender.build_transaction(action: 'authorize')
+      Payment::Authorize::Affirm.new(tender, transaction).complete!
+      assert(transaction.success?, 'expected transaction to be successful')
+    end
+
+    def test_purchase
+      transaction = tender.build_transaction(action: 'purchase')
+      Payment::Purchase::Affirm.new(tender, transaction).complete!
+      assert(transaction.success?)
+    end
+
+    def test_auth_void
+      transaction = tender.build_transaction(action: 'authorize')
+      operation = Payment::Authorize::Affirm.new(tender, transaction)
+      operation.complete!
+      assert(transaction.success?, 'expected transaction to be successful')
+      transaction.save!
+
+      operation.cancel!
+      void = transaction.cancellation
+
+      assert(void.success?)
+    end
+
+    private
+
+    def payment
+      @payment ||=
+        begin
+          profile = create_payment_profile
+          create_payment(
+            profile_id: profile.id,
+            address: {
+              first_name: 'Ben',
+              last_name: 'Crouse',
+              street: '22 s. 3rd st.',
+              city: 'Philadelphia',
+              region: 'PA',
+              postal_code: '19106',
+              country: Country['US']
+            }
+          )
+        end
+    end
+
+    def tender
+      @tender ||=
+        begin
+          payment.set_address(first_name: 'Ben', last_name: 'Crouse')
+
+          payment.build_affirm(
+            checkout_token: '12345',
+            details: { foo: 'bar' }
+          )
+
+          payment.affirm
+        end
+    end
+  end
+end

--- a/test/services/workarea/affirm/order_test.rb
+++ b/test/services/workarea/affirm/order_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+module Workarea
+  module Affirm
+    class OrderTest < Workarea::TestCase
+      def test_to_hash
+        Workarea.config.affirm_merchant_name = "Workarea test merchant"
+        order = Workarea::Storefront::OrderViewModel.new(create_placed_order)
+
+        hash = Order.new(order.id).to_hash
+
+        assert_equal(order.id, hash[:order_id])
+        assert_equal(order.order_balance.cents, hash[:total])
+        assert_equal(order.tax_total.cents, hash[:tax_amount])
+        assert_equal(order.shipping_total.cents, hash[:shipping_amount])
+
+        assert_equal("Workarea test merchant", hash[:merchant][:name])
+
+        affirm_shipping = hash[:shipping]
+        assert_equal({ first: "Ben", last: "Crouse" }, affirm_shipping[:name])
+        assert_equal(order.email, affirm_shipping[:email])
+        assert_equal(order.shipping_address.street, affirm_shipping[:address][:line1])
+        assert_equal(order.shipping_address.city, affirm_shipping[:address][:city])
+        assert_equal(order.shipping_address.region, affirm_shipping[:address][:state])
+        assert_equal(order.shipping_address.postal_code, affirm_shipping[:address][:zipcode])
+        assert_equal(order.shipping_address.country.alpha3, affirm_shipping[:address][:country])
+
+        affirm_billing = hash[:billing]
+        assert_equal({ first: "Ben", last: "Crouse" }, affirm_billing[:name])
+        assert_equal(order.email, affirm_billing[:email])
+        assert_equal(order.billing_address.street, affirm_billing[:address][:line1])
+        assert_equal(order.billing_address.city, affirm_billing[:address][:city])
+        assert_equal(order.billing_address.region, affirm_billing[:address][:state])
+        assert_equal(order.billing_address.postal_code, affirm_billing[:address][:zipcode])
+        assert_equal(order.billing_address.country.alpha3, affirm_billing[:address][:country])
+
+        affirm_item = hash[:items].first
+        assert_equal("Test Product", affirm_item[:display_name])
+        assert_equal("SKU", affirm_item[:sku])
+        assert_equal(500, affirm_item[:unit_price])
+        assert_equal(2, affirm_item[:qty])
+      end
+    end
+  end
+end

--- a/test/system/workarea/storefront/affirm_cart_system_test.rb
+++ b/test/system/workarea/storefront/affirm_cart_system_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+
+module Workarea
+  module Storefront
+    class CartSystemTest < Workarea::SystemTest
+      setup :set_inventory
+      setup :set_product
+      setup :set_affirm
+
+      def set_inventory
+        create_inventory(id: 'SKU1', policy: 'standard', available: 2)
+      end
+
+      def set_product
+        @product = create_product(
+          name: 'Integration Product',
+          variants: [
+            { name: 'SKU1', sku: 'SKU1', regular: 5.to_m },
+            { name: 'SKU2', sku: 'SKU2', regular: 6.to_m }
+          ]
+        )
+      end
+
+      def set_affirm
+        Workarea.config.affirm_public_key = 'x'
+        Workarea.config.affirm_private_key = 'y'
+      end
+
+      def test_order_value_does_not_meet_affirm_threshold
+        Workarea.config.affirm_minimum_order_value = 500.00
+
+        visit storefront.product_path(@product)
+        select @product.skus.first, from: 'sku'
+        click_button t('workarea.storefront.products.add_to_cart')
+
+        assert(page.has_content?('Success'))
+        assert(page.has_content?(@product.name))
+
+        click_link t('workarea.storefront.carts.view_cart')
+        refute(page.has_selector?('.affirm-as-low-as', visible: false))
+      end
+
+       def test_show_affirm_message
+        Workarea.config.affirm_minimum_order_value = nil
+
+        visit storefront.product_path(@product)
+        select @product.skus.first, from: 'sku'
+        click_button t('workarea.storefront.products.add_to_cart')
+
+        assert(page.has_content?('Success'))
+        assert(page.has_content?(@product.name))
+
+        click_link t('workarea.storefront.carts.view_cart')
+        assert(page.has_selector?('.affirm-as-low-as', visible: false))
+      end
+    end
+  end
+end

--- a/test/system/workarea/storefront/affirm_logged_in_checkout_system_test.rb
+++ b/test/system/workarea/storefront/affirm_logged_in_checkout_system_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+module Workarea
+  module Storefront
+    class AffirmLoggedInCheckoutSystemTest < Workarea::SystemTest
+      include Storefront::SystemTest
+
+      setup :set_affirm
+      setup :setup_checkout_specs
+      setup :add_user_data
+      setup :start_user_checkout
+
+      def set_affirm
+        Workarea.config.affirm_public_key = 'x'
+        Workarea.config.affirm_private_key = 'y'
+      end
+
+      def test_affirm_option_in_checkout
+        choose 'payment_affirm'
+        assert(page.has_content?(I18n.t('workarea.storefront.affirm.on_continue')))
+      end
+    end
+  end
+end

--- a/workarea-affirm.gemspec
+++ b/workarea-affirm.gemspec
@@ -9,9 +9,9 @@ Gem::Specification.new do |spec|
   spec.version     = Workarea::Affirm::VERSION
   spec.authors     = ["Jeff Yucis"]
   spec.email       = ["jyucis@workarea.com"]
-  spec.homepage    = "TODO"
-  spec.summary     = "TODO: Summary of Affirm."
-  spec.description = "TODO: Description of Affirm."
+  spec.homepage    = "https://github.com/workarea-commerce/workarea-affirm"
+  spec.summary     = "Affirm payments for Workarea Commerce"
+  spec.description = "Affirm payments solution"
   spec.license     = "Business Software License"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files`.split("\n")
 
   spec.add_dependency 'workarea', '~> 3.x'
+  spec.add_dependency "faraday", "~> 0.10"
 end


### PR DESCRIPTION
Add affirm as a primary payment tender. Enables promo messaging
using JS sdk.

AFFIRM-1