### PR TITLE
Add Platform Metadata

### DIFF
--- a/app/services/workarea/affirm/order.rb
+++ b/app/services/workarea/affirm/order.rb
@@ -40,7 +40,8 @@ module Workarea
           order_id: order.id,
           shipping_amount: order.shipping_total.cents,
           tax_amount: order.tax_total.cents,
-          total: order.order_balance.cents
+          total: order.order_balance.cents,
+          metadata: metadata
         }
       end
 
@@ -100,6 +101,19 @@ module Workarea
 
       def host
         "https://#{Workarea.config.host}"
+      end
+
+      # This is used for platform attribution. Please do not change
+      # these values.
+      #
+      # @private
+      # @return [Hash]
+      def metadata
+        {
+          platform_type: 'Workarea',
+          platform_version: Workarea::VERSION::STRING,
+          platform_affirm: Workarea::Affirm::VERSION
+        }
       end
     end
   end

--- a/test/services/workarea/affirm/order_test.rb
+++ b/test/services/workarea/affirm/order_test.rb
@@ -39,6 +39,11 @@ module Workarea
         assert_equal("SKU", affirm_item[:sku])
         assert_equal(500, affirm_item[:unit_price])
         assert_equal(2, affirm_item[:qty])
+
+        metadata = hash[:metadata]
+        assert_equal('Workarea', metadata[:platform_type])
+        assert_equal(Workarea::VERSION::STRING, metadata[:platform_version])
+        assert_equal(Workarea::Affirm::VERSION, metadata[:platform_affirm])
       end
     end
   end


### PR DESCRIPTION
Include a `:metadata` key in the JSON hash sent to Affirm, specifying the platform name ("Workarea"), current platform version, and current `Workarea::Affirm` version. This is used by Affirm for platform attribution.