### PR TITLE
Revise Checkout Messaging

### DIFF
--- a/app/views/workarea/storefront/checkouts/_affirm_payment.html.haml
+++ b/app/views/workarea/storefront/checkouts/_affirm_payment.html.haml
@@ -24,6 +24,6 @@
       %p.checkout-payment__primary-method-description
         %span.affirm-as-low-as.affirm-as-low-as--payment{ data: { amount: step.order.total_price.cents, affirm_type: 'text', learnmore_show: 'false'}}
       %p.checkout-payment__primary-method-edit
-        %span= t('workarea.storefront.affirm.on_continue')
+        %span= t('workarea.storefront.affirm.on_continue_html')
 
       = render 'workarea/storefront/checkouts/affirm_cart'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,7 +21,7 @@ en:
         check_out: Check Out with affirm
         checkout_submit_text: Continue to Affirm
         disqualifying_items: One or more items in your cart do not qualify for Affirm payment.
-        on_continue: When you continue, you will be taken to the Affirm website to complete your order.
+        on_continue_html: <strong>How does Affirm work?</strong><br><br>You will be redirected to Affirm to securely complete your purchase. Just fill out a few pieces of basic information and get a real-time decision. Checking your eligibility won't affect your credit score.
         paid_with_affirm: Paid with Affirm
         payment_error: There was a problem processing your Affirm payment.
         affirm: Affirm

--- a/test/system/workarea/storefront/affirm_logged_in_checkout_system_test.rb
+++ b/test/system/workarea/storefront/affirm_logged_in_checkout_system_test.rb
@@ -17,7 +17,11 @@ module Workarea
 
       def test_affirm_option_in_checkout
         choose 'payment_affirm'
-        assert(page.has_content?(I18n.t('workarea.storefront.affirm.on_continue')))
+
+        assert_match(
+          I18n.t('workarea.storefront.affirm.on_continue_html'),
+          page.body
+        )
       end
     end
   end


### PR DESCRIPTION
Change the messaging in the payment step of checkout to some copy text that Affirm provided for us. This gives a bit more information about Affirm's payment and how it works.