### PR TITLE
Prevent Purchasing Gift Cards Using Affirm

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,4 @@ gemspec
 # To use a debugger
 # gem 'byebug', group: %i[development test]
 gem 'workarea', github: 'workarea-commerce/workarea', branch: 'v3.5-stable'
+gem 'workarea-gift_cards'

--- a/app/models/workarea/catalog/product.decorator
+++ b/app/models/workarea/catalog/product.decorator
@@ -1,7 +1,36 @@
 module Workarea
   decorate Catalog::Product, with: 'affirm' do
     decorated do
-      field :affirm_available, type: Boolean, default: true
+      field :affirm_available, type: Boolean, default: -> {
+        default_affirm_available
+      }
+      validate :gift_card_cannot_be_purchased_using_affirm
+    end
+
+    private
+
+    # Affirm does not allow a gift card to be purchased using its
+    # service, so this validation prevents admins (or anyone else) from
+    # setting both of these flags to true.
+    #
+    # @private
+    def gift_card_cannot_be_purchased_using_affirm
+      if try(:gift_card?) && affirm_available?
+        cannot_be_set_for_gift_cards = I18n.t(
+          'workarea.admin.catalog_products.affirm.cannot_be_set_for_gift_cards'
+        )
+
+        errors.add(:affirm_available, cannot_be_set_for_gift_cards)
+      end
+    end
+
+    # The default value for `:affirm_available` depends on whether the
+    # Gift Cards plugin is installed, and `:gift_card` is set to true.
+    #
+    # @private
+    # @return [Boolean] Default value for the `:affirm_available` field.
+    def default_affirm_available
+      try(:gift_card?) ? false : true
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,7 @@ en:
           allow_affirm: Allow Affirm payment for this product
           allow: Allowed
           not_allowed: Not Allowed
+          cannot_be_set_for_gift_cards: cannot be set for gift cards
       orders:
         tenders:
           affirm:

--- a/test/integration/workarea/storefront/products_integration_test.decorator
+++ b/test/integration/workarea/storefront/products_integration_test.decorator
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+module Workarea
+  module Storefront
+    decorate ProductsIntegrationTest, with: :affirm do
+      def test_rendering_via_params
+        return super unless Plugin.installed?(:gift_cards)
+
+        Workarea.config.product_templates.delete(:gift_card)
+
+        super
+
+        product = create_product(template: :gift_card)
+        category = create_category
+
+        get storefront.product_path(product, via: category.to_gid_param)
+        assert_select(
+          'form.product-details__add-to-cart-form input[name="via"][value=?]',
+          category.to_gid_param
+        )
+      end
+    end
+  end
+end

--- a/test/models/workarea/catalog/affirm_gift_card_product_test.rb
+++ b/test/models/workarea/catalog/affirm_gift_card_product_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+module Workarea
+  module Catalog
+    class AffirmGiftCardProductTest < TestCase
+      if Workarea::Plugin.installed? :gift_cards
+        def test_gift_cards_cannot_be_purchased_with_affirm
+          product = create_product(gift_card: true)
+
+          assert(product.gift_card?)
+          refute(product.affirm_available?)
+          refute(product.update(affirm_available: true))
+          assert(product.errors[:affirm_available].present?)
+          assert(product.update(affirm_available: true, gift_card: false))
+
+          product = create_product(affirm_available: true)
+
+          assert(product.affirm_available?)
+          refute(product.gift_card?)
+        end
+      end
+    end
+  end
+end

--- a/test/system/workarea/storefront/affirm_cart_system_test.rb
+++ b/test/system/workarea/storefront/affirm_cart_system_test.rb
@@ -54,7 +54,7 @@ module Workarea
         refute(page.has_selector?('.affirm-as-low-as', visible: false))
       end
 
-       def test_show_affirm_message
+      def test_show_affirm_message
         Workarea.config.affirm_minimum_order_value = nil
 
         visit storefront.product_path(@product)


### PR DESCRIPTION
According to Affirm, they do not allow gift cards to be purchased using their service. This prevents a product marked as a gift card from being purchased using Affirm, via the existing `affirm_available` flag.