### PR TITLE
Fix Currency ISO Code

### DIFF
--- a/app/services/workarea/affirm/order.rb
+++ b/app/services/workarea/affirm/order.rb
@@ -47,7 +47,7 @@ module Workarea
           tax_amount: order.tax_total.cents,
           total: order.order_balance.cents,
           metadata: metadata,
-          currency: order.order_balance.currency,
+          currency: order.order_balance.currency.iso_code,
           discounts: discounts
         }
       end

--- a/test/services/workarea/affirm/order_test.rb
+++ b/test/services/workarea/affirm/order_test.rb
@@ -31,7 +31,7 @@ module Workarea
         assert_equal(order.order_balance.cents, hash[:total])
         assert_equal(order.tax_total.cents, hash[:tax_amount])
         assert_equal(order.shipping_total.cents, hash[:shipping_amount])
-        assert_equal(Money.default_currency, hash[:currency])
+        assert_equal(Money.default_currency.iso_code, hash[:currency])
 
         assert_equal("Workarea test merchant", hash[:merchant][:name])
 


### PR DESCRIPTION
We were sending the whole Currency object, but it really should just be the ISO code.