### PR TITLE
Remove Extra Data Attribute

### DIFF
--- a/app/views/workarea/storefront/carts/_affirm_cart_promo_messaging.html.haml
+++ b/app/views/workarea/storefront/carts/_affirm_cart_promo_messaging.html.haml
@@ -1,5 +1,5 @@
 - if Workarea::Affirm.enabled? && Workarea.config.affirm_show_cart_messaging && current_order.affirm_available? && @cart.total_price >= Workarea.config.affirm_minimum_order_value.to_m
-  .affirm-as-low-as.affirm-as-low-as--cart{ data: { amount: @cart.total_price.cents, affirm_color: Workarea.config.affirm_cart_logo_color, affirm_type: Workarea.config.affirm_cart_logo_type, learnmore_show: 'false'}}
+  .affirm-as-low-as.affirm-as-low-as--cart{ data: { amount: @cart.total_price.cents, affirm_color: Workarea.config.affirm_cart_logo_color, affirm_type: Workarea.config.affirm_cart_logo_type } }
   .affirm-as-low-as__subtext
     = t('workarea.storefront.affirm.select')
     %span.payment-icon.payment-icon--affirm

--- a/app/views/workarea/storefront/checkouts/_affirm_payment.html.haml
+++ b/app/views/workarea/storefront/checkouts/_affirm_payment.html.haml
@@ -22,7 +22,7 @@
         = label_tag 'payment[affirm]', nil, class: 'button-property__name' do
           %span.payment-icon.payment-icon--affirm
       %p.checkout-payment__primary-method-description
-        %span.affirm-as-low-as.affirm-as-low-as--payment{ data: { amount: step.order.total_price.cents, affirm_type: 'text', learnmore_show: 'false'}}
+        %span.affirm-as-low-as.affirm-as-low-as--payment{ data: { amount: step.order.total_price.cents, affirm_type: 'text' } }
       %p.checkout-payment__primary-method-edit
         %span= t('workarea.storefront.affirm.on_continue_html')
 

--- a/app/views/workarea/storefront/products/_affirm_product_promo_messaging.html.haml
+++ b/app/views/workarea/storefront/products/_affirm_product_promo_messaging.html.haml
@@ -1,5 +1,5 @@
 - if Workarea::Affirm.enabled? && Workarea.config.affirm_show_pdp_messaging && @product.affirm_available? && @product.sell_min_price.present?
-  .affirm-as-low-as.affirm-as-low-as--pdp{ data: { amount: @product.sell_min_price.cents, affirm_color: Workarea.config.affirm_pdp_logo_color, affirm_type: Workarea.config.affirm_pdp_logo_type, learnmore_show: 'false'}}
+  .affirm-as-low-as.affirm-as-low-as--pdp{ data: { amount: @product.sell_min_price.cents, affirm_color: Workarea.config.affirm_pdp_logo_color, affirm_type: Workarea.config.affirm_pdp_logo_type } }
   .affirm-as-low-as__subtext
     Select
     %span.payment-icon.payment-icon--affirm


### PR DESCRIPTION
The `data-learnmore-show="false"` attribute added to Affirm elements is not necessary, so it has been removed.