### PR TITLE
Fix Discount Notation in Checkout Object

### DIFF
--- a/app/services/workarea/affirm/order.rb
+++ b/app/services/workarea/affirm/order.rb
@@ -134,10 +134,9 @@ module Workarea
       def discounts
         discount_adjustments.each_with_object({}) do |adjustment, discounts|
           code = adjustment.data['discount_id'] || adjustment.id
-          discounts[code] = {
-            discount_amount: adjustment.amount.cents.abs,
-            discount_display_name: adjustment.description
-          }
+          discounts[code] ||= { discount_amount: 0 }
+          discounts[code][:discount_display_name] ||= adjustment.description
+          discounts[code][:discount_amount] += adjustment.amount.cents.abs
         end
       end
 


### PR DESCRIPTION
Multiple discounts for the same order overrode each other in the hash going to Affirm, this ensures that the hash specified by discount ID can be appended to as new adjustments are found using the same discount.